### PR TITLE
feat: add Plane integration to automation hooks

### DIFF
--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -89,9 +89,18 @@ Given that feature description, do this:
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
 
-3. Load `.specify/templates/spec-template.md` to understand required sections.
+3. **Plane project setup (if Plane MCP available)**: If Plane MCP tools are available (e.g. `create_work_item` exists):
+   - Read `.claude/skills/plane-dev/references/projects.md`
+   - If no project exists for this repo, create one: `create_project(name=<repo name>, identifier=<3-5 char acronym>)`
+   - Capture project ID and state UUIDs with `list_states(project_id)`, update `references/projects.md`
+   - Create a parent work item from the feature description: `create_work_item(project_id, name=<feature title>, description_html=<feature description>, state=<todo UUID>)`
+   - Include the ticket identifier (e.g. `PROJ-1`) in the branch name if not already present
+   - Announce: `"✓ Plane: Created PROJ-N — <feature title>"`
+   - If Plane MCP is not available, skip this step silently.
 
-4. Follow this execution flow:
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
 
     1. Parse user description from Input
        If empty: ERROR "No feature description provided"
@@ -117,9 +126,9 @@ Given that feature description, do this:
     7. Identify Key Entities (if data involved)
     8. Return: SUCCESS (spec ready for planning)
 
-5. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
 
-6. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
 
    a. **Create Spec Quality Checklist**: Generate a checklist file at `FEATURE_DIR/checklists/requirements.md` using the checklist template structure with these validation items:
 
@@ -211,9 +220,9 @@ Given that feature description, do this:
 
    d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
 
-7. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
+8. Report completion with branch name, spec file path, checklist results, and readiness for the next phase (`/speckit.clarify` or `/speckit.plan`).
 
-8. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
    - If it exists, read it and look for entries under the `hooks.after_specify` key
    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.

--- a/.claude/commands/speckit.taskstoissues.md
+++ b/.claude/commands/speckit.taskstoissues.md
@@ -1,5 +1,5 @@
 ---
-description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+description: Convert existing tasks into actionable, dependency-ordered issues in GitHub or Plane based on available design artifacts.
 tools: ['github/github-mcp-server/issue_write']
 ---
 
@@ -15,6 +15,23 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 1. From the executed script, extract the path to **tasks**.
+
+### Choose target: Plane or GitHub
+
+1. Check if Plane MCP tools are available (e.g. `create_work_item`). If available AND the user passed `--plane` or `plane` in arguments, use **Plane mode**. If unavailable or not requested, fall through to **GitHub mode**.
+
+### Plane mode
+
+1. Read `.claude/skills/plane-dev/references/projects.md` to get the project ID and state UUIDs. If no project exists yet, create one with `create_project()` and populate `references/projects.md`.
+2. Create a **parent work item** from the feature name/description with state = Todo.
+3. For each task in the list, create a **child work item** under the parent:
+   - `create_work_item(project_id, name=<task title>, description_html=<task content>, parent=<parent UUID>, state=<todo UUID>)`
+4. If tasks have explicit ordering or dependencies, create `blocked_by` relations.
+5. Move parent to **In Progress**.
+6. Report: list of created tickets with identifiers.
+
+### GitHub mode
+
 1. Get the Git remote by running:
 
 ```bash

--- a/.claude/hooks/on-stop.sh
+++ b/.claude/hooks/on-stop.sh
@@ -52,6 +52,12 @@ if [ -f "$SESSION_FILE" ]; then
   if echo "$LAST_MSG" | grep -qE 'github\.com/.*/pull/[0-9]+' 2>/dev/null; then
     rm -f "$SESSION_FILE"
     touch "$DISARM_FILE"
+    # Hint to close Plane ticket
+    STOP_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+    PLANE_TICKET=$(echo "$STOP_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+    if [ -n "$PLANE_TICKET" ]; then
+      echo "{\"additionalContext\": \"PLANE ACTION: PR created for ${PLANE_TICKET}. If Plane MCP is available, move the parent ticket to Done.\"}"
+    fi
     if command -v osascript &>/dev/null; then
       osascript -e 'display notification "PR created — session complete. Exiting cleanly." with title "Claude Code" sound name "Hero"' 2>/dev/null || true
     elif command -v notify-send &>/dev/null; then

--- a/.claude/hooks/on-stop.sh
+++ b/.claude/hooks/on-stop.sh
@@ -55,9 +55,6 @@ if [ -f "$SESSION_FILE" ]; then
     # Hint to close Plane ticket
     STOP_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
     PLANE_TICKET=$(echo "$STOP_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
-    if [ -n "$PLANE_TICKET" ]; then
-      echo "{\"additionalContext\": \"PLANE ACTION: PR created for ${PLANE_TICKET}. If Plane MCP is available, move the parent ticket to Done.\"}"
-    fi
     if command -v osascript &>/dev/null; then
       osascript -e 'display notification "PR created — session complete. Exiting cleanly." with title "Claude Code" sound name "Hero"' 2>/dev/null || true
     elif command -v notify-send &>/dev/null; then

--- a/.claude/hooks/post-commit-review.sh
+++ b/.claude/hooks/post-commit-review.sh
@@ -55,6 +55,12 @@ if [ -n "$COMMIT_SHA" ]; then
   git -C "$REPO_ROOT" log -1 --format="%H %s" > "${PENDING_DIR}/${COMMIT_SHA}.pending"
 
   REVIEW_MSG="REVIEW REQUIRED: Commit ${COMMIT_SHA} queued for review. The review-enforcer hook will BLOCK your next implementation action until reviews are complete. Dispatch these three agents IN PARALLEL (all have background: true): (1) Agent tool with subagent_type=spec-reviewer, (2) Agent tool with subagent_type=code-quality-reviewer, (3) Agent tool with subagent_type=code-simplifier-reviewer. Each agent reads .reviews/pending/, reviews the diff, and writes a signed artifact to .reviews/completed/. Do NOT write review files manually — the agents handle it."
+  # Detect Plane ticket from branch for post-commit update
+  PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+  if [ -n "$PLANE_TICKET" ]; then
+    COMMIT_MSG=$(git -C "$REPO_ROOT" log -1 --format="%s" 2>/dev/null || true)
+    REVIEW_MSG="${REVIEW_MSG} PLANE ACTION: If Plane MCP is available, update ticket ${PLANE_TICKET} — add comment with commit ${COMMIT_SHA}: '${COMMIT_MSG}'. If this completes a child task, move it to Done and check if all siblings are done (move parent to In Review if so)."
+  fi
   if [ -n "${BRANCH_WARNING:-}" ]; then
     REVIEW_MSG="${REVIEW_MSG} ${BRANCH_WARNING}"
   fi

--- a/.claude/hooks/post-commit-review.sh
+++ b/.claude/hooks/post-commit-review.sh
@@ -58,7 +58,7 @@ if [ -n "$COMMIT_SHA" ]; then
   # Detect Plane ticket from branch for post-commit update
   PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
   if [ -n "$PLANE_TICKET" ]; then
-    COMMIT_MSG=$(git -C "$REPO_ROOT" log -1 --format="%s" 2>/dev/null || true)
+    COMMIT_MSG=$(git -C "$REPO_ROOT" log -1 --format="%s" 2>/dev/null | sed 's/"/\\"/g' | tr '\n' ' ' || true)
     REVIEW_MSG="${REVIEW_MSG} PLANE ACTION: If Plane MCP is available, update ticket ${PLANE_TICKET} — add comment with commit ${COMMIT_SHA}: '${COMMIT_MSG}'. If this completes a child task, move it to Done and check if all siblings are done (move parent to In Review if so)."
   fi
   if [ -n "${BRANCH_WARNING:-}" ]; then

--- a/.claude/hooks/review-gate.sh
+++ b/.claude/hooks/review-gate.sh
@@ -81,4 +81,11 @@ SESSION_FILE="/tmp/claude-session-active-${REPO_HASH}"
 rm -f "$SESSION_FILE"
 touch "/tmp/claude-session-disarmed-${REPO_HASH}"
 
+# Hint to link PR to Plane ticket
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+if [ -n "$PLANE_TICKET" ]; then
+  echo "{\"additionalContext\": \"PLANE ACTION: After creating the PR, link it to Plane ticket ${PLANE_TICKET} using create_work_item_link. Move the parent ticket to In Review state.\"}"
+fi
+
 exit 0

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -45,6 +45,15 @@ if [ -d "$PENDING_DIR" ]; then
   fi
 fi
 
+# Detect Plane ticket from branch name
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+if [ -n "$PLANE_TICKET" ]; then
+  PROJ_ID=$(echo "$PLANE_TICKET" | grep -oE '^[A-Z]+')
+  ISSUE_NUM=$(echo "$PLANE_TICKET" | grep -oE '[0-9]+$')
+  CONTEXT_PARTS="${CONTEXT_PARTS:+$CONTEXT_PARTS }Plane ticket ${PLANE_TICKET} detected from branch. If Plane MCP is available, run retrieve_work_item_by_identifier(project_identifier=\"${PROJ_ID}\", issue_identifier=${ISSUE_NUM}) to load current ticket state."
+fi
+
 # Output context if we found anything useful
 if [ -n "$CONTEXT_PARTS" ]; then
   # Escape for JSON

--- a/.claude/skills/plane-dev/SKILL.md
+++ b/.claude/skills/plane-dev/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: plane-dev
+description: Plane project management integration for the Superpowers development workflow. Hooks into Superpowers lifecycle: brainstorming design doc → create parent ticket; writing-plans plan doc → create child tickets per Task block; subagent-driven-development task complete → mark Done + commit comment; finishing-a-development-branch PR → link PR, move to In Review. Also handles: ingesting Claude native/.specify/generic markdown specs, board snapshot, standup, git log sync, board health check, zero-to-board from rough idea, auto-labelling. Triggers on: Superpowers lifecycle events, "ingest spec", "create tickets", "start working on", "task complete", "mark done", "update plane", "sync plane", "show the board", "standup", "what ticket am I on", "health check", "stale tickets", "build me a", "add labels", "PR opened".
+---
+
+# Plane Dev — Superpowers Integration
+
+Plane is the source of truth for all work. Every Superpowers lifecycle event has a corresponding Plane action. No manual tracking.
+
+## Workspace
+
+> **Setup required:** populate these values from your Plane instance, or run `list_projects()` to discover them.
+
+- **Slug:** `<your-workspace-slug>`
+- **User ID:** `<your-user-uuid>`
+- **Base URL:** `<your-plane-instance-url>`
+- **Style:** Kanban — see `references/projects.md` for project IDs + state UUIDs
+
+---
+
+## Superpowers Lifecycle Hooks
+
+### Hook 1: After `brainstorming` → Create Parent Ticket
+
+Triggered when: brainstorming skill writes its design doc to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`
+
+**Action:**
+1. Read the design doc — extract title, goal, and key sections
+2. Create parent ticket:
+   ```
+   create_work_item(project_id, name=<feature title>,
+     description_html=<design doc converted to HTML>,
+     priority=<inferred>, state=<todo UUID>)
+   ```
+3. Move to **In Progress**: `update_work_item(state=<started UUID>)`
+4. **Announce:** `"Created Plane ticket PROJ-N: <title>"`
+
+---
+
+### Hook 2: After `writing-plans` → Create Child Tickets
+
+Triggered when: writing-plans skill writes `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`
+
+The plan file uses Superpowers task structure — groups of `- [ ]` steps under `### Task N: <name>` headings.
+
+**Action:**
+1. Parse the plan file — extract each `### Task N: <Component Name>` block
+2. For each Task block, create one child ticket:
+   ```
+   create_work_item(project_id, name="Task N: <Component Name>",
+     description_html=<task block as HTML>,
+     parent=<parent ticket UUID>,
+     state=<todo UUID>, priority="medium")
+   ```
+3. If task descriptions mention explicit ordering ("after Task 2", "requires Task 1") — create `blocked_by` relations
+4. **Announce:** `"Created N child tickets for PROJ-X. Ready to implement."`
+
+> **Note:** Map Superpowers tasks (2-5 min granular steps) at the `### Task N` level — not individual `- [ ]` step level. Each Task block = one Plane ticket.
+
+---
+
+### Hook 3: During `subagent-driven-development` → Mark Tasks Done
+
+Triggered when: a task is marked complete (`- [x]`) in the plan, or `subagent-driven-development` announces a task is done.
+
+**Action — after each completed task:**
+1. Find the matching child ticket by name/number
+2. Move to **Done**: `update_work_item(state=<completed UUID>)`
+3. Add comment with the commit ref:
+   ```
+   create_work_item_comment(project_id, work_item_id,
+     comment_html="<p><strong>Done</strong> — <code>PROJ-N: commit message</code></p>")
+   ```
+4. Check if all children are done → if so, prompt to move parent to Done or In Review
+
+---
+
+### Hook 4: `finishing-a-development-branch` → Link PR
+
+Triggered when: finishing-a-development-branch skill creates a PR (Option 2).
+
+**Action:**
+1. Get the PR URL from `gh pr create` output
+2. Link to parent ticket: `create_work_item_link(project_id, parent_id, url=<PR URL>)`
+3. Move parent to **In Review** (started group) if not already Done
+4. Add comment: `"<p>PR opened: <a href='...'>link</a></p>"`
+5. After merge → move parent to **Done**
+
+---
+
+## Manual Spec Ingestion (Non-Superpowers Specs)
+
+When given a spec that wasn't produced by Superpowers, parse it using `references/spec-formats.md`:
+- **Claude native** — `.claude/specs/<feature>/requirements.md + design.md + tasks.md`
+- **SpecKit** — `.specify/specs/<NNN>-slug/spec.md + plan.md + tasks.md`
+- **Generic markdown** — any file with a task list section
+
+Then follow Hook 1 + Hook 2 logic to create parent + child tickets.
+
+---
+
+## Branch Naming
+
+Always create the Git branch right after Hook 1:
+```
+git checkout -b feature/PROJ-<n>-<slug>
+```
+Types: `feature|fix|chore|refactor`. Slug = kebab-case feature title.
+
+Commit format: `PROJ-42: short description` (matches Superpowers TDD commit cadence).
+
+---
+
+## Auto-detect Current Ticket
+
+When no ticket is specified, parse the current branch:
+```bash
+git branch --show-current  # → "feature/PROJ-42-add-oauth"
+```
+Extract `PROJ-42` → `retrieve_work_item_by_identifier(project_identifier="PROJ", issue_identifier=42)`
+
+---
+
+## Superpowers — Plane Integration Rules
+
+- **Never block Superpowers flow.** Plane updates happen *after* each Superpowers step completes — never interrupt brainstorming, planning, or implementation.
+- **Announce Plane actions briefly.** One line: `"✓ Plane: PROJ-42 → In Progress"`
+- **On failure, don't halt.** If a Plane API call fails, log it and continue. Catch up later.
+- **Batch when possible.** After a subagent session, update multiple tickets in one pass rather than one call per step.
+
+---
+
+## Hook-Driven Automation
+
+The automation hooks in `.claude/hooks/` inject Plane context at key lifecycle points.
+Claude reads these hints and makes the appropriate MCP calls guided by this skill.
+
+| Hook | Event | Plane Context Injected |
+|------|-------|----------------------|
+| `session-init.sh` | SessionStart | Detects `PROJ-N` from branch, prompts ticket state lookup |
+| `post-commit-review.sh` | After feat: commit | Prompts to add commit comment + mark child ticket Done |
+| `review-gate.sh` | PR gate passes | Prompts to link PR to parent ticket, move to In Review |
+| `on-stop.sh` | PR detected in output | Prompts to move parent ticket to Done |
+| `speckit.specify` | Feature spec created | Creates Plane project + parent ticket if MCP available |
+| `speckit.taskstoissues --plane` | Tasks generated | Creates child tickets from tasks.md |
+
+These hooks are additive — if Plane MCP is not configured, the hints are ignored.
+The hooks never call the Plane API directly; they only inject `additionalContext` JSON.
+
+---
+
+## Superpowers Reference
+
+See `references/superpowers-hooks.md` for the complete hook trigger map, plan file format details, and edge cases.
+See `references/projects.md` for project IDs and state UUIDs.
+See `references/superpowers.md` for additional power commands (board snapshot, standup, git sync, health check, auto-label, zero-to-board).

--- a/.claude/skills/plane-dev/references/projects.md
+++ b/.claude/skills/plane-dev/references/projects.md
@@ -1,0 +1,27 @@
+# Plane Projects Reference
+
+This file is the living registry of projects in your workspace.
+Update it whenever a new project is created or states are mapped.
+
+## Projects
+
+_None yet. Add entries below as projects are created._
+
+<!--
+## Template entry:
+
+### Project Name
+- **ID:** `uuid-here`
+- **Identifier:** `PROJ`
+- **URL:** https://your-plane-instance/workspace/projects/uuid-here/
+
+#### States
+| Name | Group | UUID |
+|------|-------|------|
+| Backlog | backlog | `uuid` |
+| Todo | unstarted | `uuid` |
+| In Progress | started | `uuid` |
+| In Review | started | `uuid` |
+| Done | completed | `uuid` |
+| Cancelled | cancelled | `uuid` |
+-->

--- a/.claude/skills/plane-dev/references/superpowers-hooks.md
+++ b/.claude/skills/plane-dev/references/superpowers-hooks.md
@@ -1,0 +1,169 @@
+# Superpowers Hooks — Detailed Reference
+
+## Superpowers Workflow → Plane Action Map
+
+```
+Superpowers Step                          Plane Action
+─────────────────────────────────────────────────────────────────
+brainstorming → writes design doc    →   create_work_item (parent, Todo→In Progress)
+writing-plans → writes plan doc      →   create_work_item x N (children, Todo)
+                                         create_work_item_relation (blocked_by if sequential)
+subagent task complete               →   update_work_item (Done) + comment with commit
+all tasks complete                   →   prompt: move parent to In Review?
+finishing-a-development-branch PR    →   create_work_item_link (PR URL) + parent → In Review
+merge to main                        →   parent → Done
+```
+
+---
+
+## File Paths to Watch
+
+| Superpowers artifact | Path pattern |
+|---|---|
+| Design doc (brainstorming) | `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` |
+| Implementation plan (writing-plans) | `docs/superpowers/plans/YYYY-MM-DD-<feature-name>.md` |
+| Plan location override | User may set a custom path — check for it |
+
+---
+
+## Plan File Format (writing-plans output)
+
+The plan file structure to parse for Hook 2:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: ...
+
+**Goal:** One sentence.
+**Architecture:** 2-3 sentences.
+**Tech Stack:** ...
+
+---
+
+### Task 1: Component Name
+
+**Files:**
+- Create: `exact/path/to/file.py`
+- Modify: `exact/path/to/existing.py`
+- Test: `tests/exact/path/to/test.py`
+
+- [ ] **Step 1: Write the failing test**
+  ...
+- [ ] **Step 2: Run test to verify it fails**
+  ...
+- [ ] **Step 3: Write minimal implementation**
+  ...
+- [ ] **Step 4: Run test to verify it passes**
+  ...
+- [ ] **Step 5: Commit**
+  ...
+
+### Task 2: Another Component
+  ...
+```
+
+**Parsing rules:**
+- Split on `### Task N:` headings — each heading = one Plane child ticket
+- Include all content of the task block (files, steps) in the ticket description
+- The `- [ ]` steps within a task are Superpowers TDD micro-steps — do NOT create individual Plane tickets for them
+- Task N count = number of `### Task` headings in the plan
+
+---
+
+## Design Doc Format (brainstorming output)
+
+```markdown
+# [Feature Name] Design
+
+**Date:** YYYY-MM-DD
+**Goal:** One sentence.
+
+## Overview
+...
+
+## Approach
+...
+
+## Acceptance Criteria
+- [ ] criterion
+- [ ] criterion
+
+## Architecture
+...
+
+## Trade-offs considered
+...
+```
+
+**Parsing for parent ticket:**
+- Title: `# [Feature Name] Design` → strip " Design" suffix
+- Description: full document as `description_html`
+- Priority: look for `critical|blocker|P0` → urgent; `important|P1` → high; default → medium
+- State: Todo (unstarted group UUID)
+
+---
+
+## Subagent Completion Detection
+
+`subagent-driven-development` marks tasks done using TodoWrite. The signal that a task is complete:
+
+1. The plan file gets `- [x]` checkboxes checked for all steps in a Task block
+2. OR: the subagent-driven-development skill announces "Task N complete" / "marking task complete"
+
+When detected, look up the child ticket by matching task name/number against what was created in Hook 2.
+
+---
+
+## Edge Cases
+
+### Multiple projects in workspace
+If `list_projects()` returns multiple projects, infer the correct one from:
+1. Current git repo name matching a project name/identifier
+2. Most recent project (last active)
+3. Ask user if ambiguous
+
+### Plan written before parent ticket exists
+If `writing-plans` fires but no parent ticket was created (brainstorming was skipped), create the parent ticket from the plan's header (Goal + Architecture fields) first.
+
+### Superpowers skips brainstorming
+If writing-plans runs without a prior design doc, synthesize the parent ticket from the plan header:
+- Name: plan filename slug, humanised
+- Description: Goal + Architecture from plan header
+
+### Task names conflict
+If two tasks have the same name (unlikely but possible), append ` (N)` suffix.
+
+### No project exists yet
+Create it first:
+```
+create_project(name=<inferred from repo>, identifier=<3-5 char caps acronym>)
+list_states(project_id)  # capture UUIDs → update references/projects.md
+```
+
+### Plane API failure during implementation
+Log the failure in a local `.plane-sync-pending.json` file at the project root:
+```json
+{
+  "pending": [
+    {"action": "mark_done", "ticket": "PROJ-42", "commit": "abc123", "timestamp": "..."}
+  ]
+}
+```
+Catch up on next "sync plane" invocation.
+
+---
+
+## Commit Message Format
+
+Superpowers TDD commits happen at Step 5 of each task block:
+```bash
+git commit -m "feat: add specific feature"
+```
+
+The plane-dev skill should encourage prefixing with the ticket identifier when Plane is active:
+```bash
+git commit -m "PROJ-42: feat: add specific feature"
+```
+
+This makes `git log → batch sync` reliable since ticket refs are parseable.

--- a/.claude/skills/plane-dev/references/superpowers.md
+++ b/.claude/skills/plane-dev/references/superpowers.md
@@ -1,0 +1,172 @@
+# Superpowers Reference
+
+Advanced capabilities beyond the core workflow. Load this file when a superpower is invoked.
+
+---
+
+## Current Branch → Ticket Lookup
+
+Auto-find the Plane ticket for whatever branch you're on:
+
+```bash
+git branch --show-current
+# e.g. "feature/PROJ-42-add-oauth"
+# Extract: PROJ-42
+```
+
+Parse the branch name with regex `[A-Z]+-[0-9]+` to get the identifier, then:
+```
+retrieve_work_item_by_identifier(project_identifier="PROJ", issue_identifier=42)
+```
+
+Use this automatically at the start of any "update the ticket", "mark done", or "add a comment" request when no ticket is specified — check the branch first.
+
+---
+
+## Board Snapshot
+
+Render a live kanban view across all projects:
+
+1. `list_projects()` → get all project IDs
+2. For each project: `list_work_items(project_id)` + `list_states(project_id)`
+3. Group items by state group, render as:
+
+```
+PROJECT NAME
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Backlog (3)    Todo (2)    In Progress (1)    Done (8)
+ • PROJ-1 ...   • PROJ-5    • PROJ-7 ★          • PROJ-2
+ • PROJ-3 ...   • PROJ-6    (assigned)          • PROJ-4
+ • PROJ-9 ...                                   ...
+```
+
+Mark items assigned to you with ★. Flag items In Progress with no recent activity (check `updated_at`).
+
+---
+
+## Git Log → Batch Sync
+
+When Plane is behind after a coding session — scan git and auto-sync:
+
+```bash
+git log --oneline -30
+```
+
+Parse each commit message for ticket references (`[A-Z]+-[0-9]+`). For each unique ticket found:
+1. `retrieve_work_item_by_identifier(...)` — get current state
+2. If state is not Done: move to Done, add comment with the commit SHA/message
+3. Report what was synced
+
+Invoke automatically when user says "sync plane", "I've been coding", or "catch plane up".
+
+---
+
+## Standup Generator
+
+Generate a standup from Plane activity:
+
+```
+Done yesterday/today:
+- PROJ-12: Implemented JWT refresh logic (commit abc123)
+- PROJ-13: Fixed pagination bug
+
+In Progress:
+- PROJ-14: Auth middleware (started 2 days ago)
+
+Blocked:
+- PROJ-15: Waiting on API design decision
+
+Up Next:
+- PROJ-16: Rate limiting
+- PROJ-17: Error handling middleware
+```
+
+Steps:
+1. `list_work_items(project_id)` — get all items
+2. Filter by state group: `completed` (Done), `started` (In Progress)
+3. Check `updated_at` for recently completed items (last 24h)
+4. Scan for any comments mentioning "blocked" or `list_work_item_activities` for blockers
+5. List Todo items ordered by priority as "Up Next"
+
+---
+
+## Dependency Chains
+
+When ingesting a spec, detect sequential tasks and create `blocked_by` relations:
+
+Look for signals in the task list:
+- "after X", "once X is done", "requires X", "depends on" → explicit dependency
+- Sequential numbered lists where order matters (e.g. "1. Setup DB → 2. Create schema → 3. Write migrations")
+- Phase structure (Phase 1 tasks block Phase 2 tasks)
+
+```
+create_work_item_relation(project_id, work_item_id=task_b,
+                          relation_type="blocked_by", issues=[task_a])
+```
+
+Only create dependencies when they're clearly sequential — don't over-connect parallel tasks.
+
+---
+
+## Auto-Label
+
+Create and apply labels to keep the board filterable:
+
+**Standard label set** (create once per project, reuse):
+| Label | Color | When to apply |
+|-------|-------|---------------|
+| `frontend` | `#6366f1` | UI, components, styles |
+| `backend` | `#10b981` | API, DB, services |
+| `infra` | `#f59e0b` | CI/CD, deployment, config |
+| `tests` | `#3b82f6` | Test-only tasks |
+| `docs` | `#8b5cf6` | Documentation |
+| `bug` | `#ef4444` | Bug fixes |
+| `dx` | `#ec4899` | Developer experience |
+
+Steps:
+1. `list_labels(project_id)` — check what exists
+2. `create_label(project_id, name, color)` — create missing ones
+3. Infer labels from task content (keywords: "test", "deploy", "fix", "doc", "UI", "API", etc.)
+4. `update_work_item(labels=[...])` — apply
+
+---
+
+## Idea → Spec → Tickets (Zero-to-Board)
+
+Given a rough idea or brief description, go from nothing to a full Plane board in one shot:
+
+1. **Generate the spec inline** — write requirements, acceptance criteria, and task breakdown based on the idea
+2. **Confirm with user** — show the spec summary and task count before creating anything
+3. **Ingest** — follow the standard spec ingestion flow (parent ticket + child tasks)
+4. **Set up labels** — auto-create labels for the project
+5. **Create branch** — `git checkout -b feature/PROJ-N-slug`
+
+Trigger: "build me a...", "I want to add...", "let's spec out...", "create a board for..."
+
+---
+
+## Ticket Health Check
+
+Spot problems on the board:
+
+- **Stale In Progress** — items in `started` state with `updated_at` > 3 days ago → flag for review
+- **Orphaned tasks** — child tickets whose parent is Done but they aren't
+- **No description** — tickets with empty description (can't be worked without a spec)
+- **Unlinked PRs** — tickets in Done with no links (missing PR reference)
+
+Run: `list_work_items(project_id, expand="state")` then audit each item's metadata.
+Report as a bulleted health summary. Offer to fix each issue.
+
+---
+
+## Quick Commands Summary
+
+| Phrase | Superpower invoked |
+|--------|-------------------|
+| "what ticket am I on?" | Branch → Ticket Lookup |
+| "show the board" / "board snapshot" | Board Snapshot |
+| "sync plane" / "catch plane up" | Git Log → Batch Sync |
+| "standup" / "what did I do today?" | Standup Generator |
+| "build me a..." / "spec this out" | Idea → Spec → Tickets |
+| "health check" / "any stale tickets?" | Ticket Health Check |
+| "add labels" / "label the project" | Auto-Label |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,12 @@ All work must comply with `.specify/memory/constitution.md`:
 
 Quality gates must pass before PR: Spec, Plan, Test, Data, Simplicity.
 
+## Plane Integration (Optional)
+
+If the Plane MCP server is configured, work items are tracked in Plane automatically via the `plane-dev` skill. See `.claude/skills/plane-dev/SKILL.md` for the full lifecycle integration.
+
+@.claude/skills/plane-dev/SKILL.md
+
 ## Permission & Safety Rules
 
 - Never force push, never skip hooks, never amend published commits


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/plane-dev/` skill with full Superpowers lifecycle integration and power commands (board snapshot, standup, git sync, health check, auto-label, zero-to-board)
- Augments 4 automation hooks to inject Plane context at key lifecycle points (session start, post-commit, PR gate, session stop)
- Updates `speckit.specify` to create Plane project + parent ticket when MCP is available
- Updates `speckit.taskstoissues` to support `--plane` flag for creating child tickets in Plane
- All Plane integration is additive — zero impact when MCP is not configured

## Hook integration map

| Hook | Event | Plane Action |
|------|-------|-------------|
| `session-init.sh` | SessionStart | Detect `PROJ-N` from branch, prompt ticket state lookup |
| `post-commit-review.sh` | After feat: commit | Prompt to update ticket + mark child Done |
| `review-gate.sh` | PR gate passes | Prompt to link PR to parent, move to In Review |
| `on-stop.sh` | PR detected | Prompt to move parent to Done |

## Test plan

- [ ] Start session on a branch named `feature/PROJ-1-something` — verify session-init outputs Plane context
- [ ] Commit with `feat:` prefix on such a branch — verify post-commit outputs Plane action hint
- [ ] Run `/speckit.specify` with Plane MCP configured — verify project + parent ticket created
- [ ] Run `/speckit.taskstoissues --plane` — verify child tickets created
- [ ] Run all hooks without Plane MCP — verify no errors, Plane blocks silently skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)