### PR TITLE
feat: gate Plane hooks behind PLANE_ENABLED env var

### DIFF
--- a/.claude/commands/speckit.specify.md
+++ b/.claude/commands/speckit.specify.md
@@ -89,7 +89,7 @@ Given that feature description, do this:
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
    - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot")
 
-3. **Plane project setup (if Plane MCP available)**: If Plane MCP tools are available (e.g. `create_work_item` exists):
+3. **Plane project setup (if enabled)**: If `PLANE_ENABLED=1` is set and Plane MCP tools are available (e.g. `create_work_item` exists):
    - Read `.claude/skills/plane-dev/references/projects.md`
    - If no project exists for this repo, create one: `create_project(name=<repo name>, identifier=<3-5 char acronym>)`
    - Capture project ID and state UUIDs with `list_states(project_id)`, update `references/projects.md`

--- a/.claude/commands/speckit.taskstoissues.md
+++ b/.claude/commands/speckit.taskstoissues.md
@@ -18,7 +18,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ### Choose target: Plane or GitHub
 
-1. Check if Plane MCP tools are available (e.g. `create_work_item`). If available AND the user passed `--plane` or `plane` in arguments, use **Plane mode**. If unavailable or not requested, fall through to **GitHub mode**.
+1. Check if `PLANE_ENABLED=1` is set and Plane MCP tools are available (e.g. `create_work_item`). If both conditions met AND the user passed `--plane` or `plane` in arguments, use **Plane mode**. If either condition is unmet or not requested, fall through to **GitHub mode**.
 
 ### Plane mode
 

--- a/.claude/hooks/on-stop.sh
+++ b/.claude/hooks/on-stop.sh
@@ -52,9 +52,14 @@ if [ -f "$SESSION_FILE" ]; then
   if echo "$LAST_MSG" | grep -qE 'github\.com/.*/pull/[0-9]+' 2>/dev/null; then
     rm -f "$SESSION_FILE"
     touch "$DISARM_FILE"
-    # Hint to close Plane ticket
-    STOP_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
-    PLANE_TICKET=$(echo "$STOP_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+    # Hint to close Plane ticket (requires PLANE_ENABLED=1)
+    if [ "${PLANE_ENABLED:-}" = "1" ]; then
+      STOP_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+      PLANE_TICKET=$(echo "$STOP_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+      if [ -n "$PLANE_TICKET" ]; then
+        echo "{\"additionalContext\": \"PLANE ACTION: PR created for ${PLANE_TICKET}. If Plane MCP is available, move the parent ticket to Done.\"}"
+      fi
+    fi
     if command -v osascript &>/dev/null; then
       osascript -e 'display notification "PR created — session complete. Exiting cleanly." with title "Claude Code" sound name "Hero"' 2>/dev/null || true
     elif command -v notify-send &>/dev/null; then

--- a/.claude/hooks/post-commit-review.sh
+++ b/.claude/hooks/post-commit-review.sh
@@ -55,11 +55,13 @@ if [ -n "$COMMIT_SHA" ]; then
   git -C "$REPO_ROOT" log -1 --format="%H %s" > "${PENDING_DIR}/${COMMIT_SHA}.pending"
 
   REVIEW_MSG="REVIEW REQUIRED: Commit ${COMMIT_SHA} queued for review. The review-enforcer hook will BLOCK your next implementation action until reviews are complete. Dispatch these three agents IN PARALLEL (all have background: true): (1) Agent tool with subagent_type=spec-reviewer, (2) Agent tool with subagent_type=code-quality-reviewer, (3) Agent tool with subagent_type=code-simplifier-reviewer. Each agent reads .reviews/pending/, reviews the diff, and writes a signed artifact to .reviews/completed/. Do NOT write review files manually — the agents handle it."
-  # Detect Plane ticket from branch for post-commit update
-  PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
-  if [ -n "$PLANE_TICKET" ]; then
-    COMMIT_MSG=$(git -C "$REPO_ROOT" log -1 --format="%s" 2>/dev/null | sed 's/"/\\"/g' | tr '\n' ' ' || true)
-    REVIEW_MSG="${REVIEW_MSG} PLANE ACTION: If Plane MCP is available, update ticket ${PLANE_TICKET} — add comment with commit ${COMMIT_SHA}: '${COMMIT_MSG}'. If this completes a child task, move it to Done and check if all siblings are done (move parent to In Review if so)."
+  # Detect Plane ticket from branch for post-commit update (requires PLANE_ENABLED=1)
+  if [ "${PLANE_ENABLED:-}" = "1" ]; then
+    PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+    if [ -n "$PLANE_TICKET" ]; then
+      COMMIT_MSG=$(git -C "$REPO_ROOT" log -1 --format="%s" 2>/dev/null | sed 's/"/\\"/g' | tr '\n' ' ' || true)
+      REVIEW_MSG="${REVIEW_MSG} PLANE ACTION: If Plane MCP is available, update ticket ${PLANE_TICKET} — add comment with commit ${COMMIT_SHA}: '${COMMIT_MSG}'. If this completes a child task, move it to Done and check if all siblings are done (move parent to In Review if so)."
+    fi
   fi
   if [ -n "${BRANCH_WARNING:-}" ]; then
     REVIEW_MSG="${REVIEW_MSG} ${BRANCH_WARNING}"

--- a/.claude/hooks/review-gate.sh
+++ b/.claude/hooks/review-gate.sh
@@ -81,11 +81,13 @@ SESSION_FILE="/tmp/claude-session-active-${REPO_HASH}"
 rm -f "$SESSION_FILE"
 touch "/tmp/claude-session-disarmed-${REPO_HASH}"
 
-# Hint to link PR to Plane ticket
-CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
-PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
-if [ -n "$PLANE_TICKET" ]; then
-  echo "{\"additionalContext\": \"PLANE ACTION: After creating the PR, link it to Plane ticket ${PLANE_TICKET} using create_work_item_link. Move the parent ticket to In Review state.\"}"
+# Hint to link PR to Plane ticket (requires PLANE_ENABLED=1)
+if [ "${PLANE_ENABLED:-}" = "1" ]; then
+  CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+  PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+  if [ -n "$PLANE_TICKET" ]; then
+    echo "{\"additionalContext\": \"PLANE ACTION: After creating the PR, link it to Plane ticket ${PLANE_TICKET} using create_work_item_link. Move the parent ticket to In Review state.\"}"
+  fi
 fi
 
 exit 0

--- a/.claude/hooks/session-init.sh
+++ b/.claude/hooks/session-init.sh
@@ -45,13 +45,15 @@ if [ -d "$PENDING_DIR" ]; then
   fi
 fi
 
-# Detect Plane ticket from branch name
-CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
-PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
-if [ -n "$PLANE_TICKET" ]; then
-  PROJ_ID=$(echo "$PLANE_TICKET" | grep -oE '^[A-Z]+')
-  ISSUE_NUM=$(echo "$PLANE_TICKET" | grep -oE '[0-9]+$')
-  CONTEXT_PARTS="${CONTEXT_PARTS:+$CONTEXT_PARTS }Plane ticket ${PLANE_TICKET} detected from branch. If Plane MCP is available, run retrieve_work_item_by_identifier(project_identifier=\"${PROJ_ID}\", issue_identifier=${ISSUE_NUM}) to load current ticket state."
+# Detect Plane ticket from branch name (requires PLANE_ENABLED=1)
+if [ "${PLANE_ENABLED:-}" = "1" ]; then
+  CURRENT_BRANCH=$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || true)
+  PLANE_TICKET=$(echo "$CURRENT_BRANCH" | grep -oE '[A-Z]+-[0-9]+' | head -1 || true)
+  if [ -n "$PLANE_TICKET" ]; then
+    PROJ_ID=$(echo "$PLANE_TICKET" | grep -oE '^[A-Z]+')
+    ISSUE_NUM=$(echo "$PLANE_TICKET" | grep -oE '[0-9]+$')
+    CONTEXT_PARTS="${CONTEXT_PARTS:+$CONTEXT_PARTS }Plane ticket ${PLANE_TICKET} detected from branch. If Plane MCP is available, run retrieve_work_item_by_identifier(project_identifier=\"${PROJ_ID}\", issue_identifier=${ISSUE_NUM}) to load current ticket state."
+  fi
 fi
 
 # Output context if we found anything useful

--- a/.claude/skills/plane-dev/SKILL.md
+++ b/.claude/skills/plane-dev/SKILL.md
@@ -7,6 +7,22 @@ description: Plane project management integration for the Superpowers developmen
 
 Plane is the source of truth for all work. Every Superpowers lifecycle event has a corresponding Plane action. No manual tracking.
 
+## Setup
+
+All Plane integration requires `PLANE_ENABLED=1` in the environment. Set it in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "PLANE_ENABLED": "1"
+  }
+}
+```
+
+Or export it in your shell profile. Without this, all hooks and commands silently skip Plane actions.
+
+You also need the Plane MCP server configured — see the project README for full setup instructions.
+
 ## Workspace
 
 > **Setup required:** populate these values from your Plane instance, or run `list_projects()` to discover them.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,52 @@ See `docs/superpowers/plans/` for per-feature implementation plans and `docs/sup
 ## Contributing
 
 This project uses a spec-driven workflow. See `.claude/commands/` for available slash commands and `.specify/memory/constitution.md` for project principles.
+
+## Plane Integration (Optional)
+
+Track work items in [Plane](https://plane.so) automatically. Hooks inject context at session start, commit, PR, and stop events.
+
+### Setup
+
+1. **Configure env var** — add to `~/.claude/settings.json`:
+   ```json
+   {
+     "env": {
+       "PLANE_ENABLED": "1",
+       "PLANE_API_KEY": "<your-api-key>",
+       "PLANE_WORKSPACE_SLUG": "<your-workspace>"
+     }
+   }
+   ```
+   Or export in your shell profile.
+
+2. **Add the Plane MCP server** — configure in `.mcp.json` or your MCP settings:
+   ```json
+   {
+     "mcpServers": {
+       "plane": {
+         "command": "python",
+         "args": ["-m", "plane_mcp", "stdio"],
+         "env": {
+           "PLANE_API_KEY": "<your-api-key>",
+           "PLANE_WORKSPACE_SLUG": "<your-workspace>"
+         }
+       }
+     }
+   }
+   ```
+
+3. **Populate project registry** — run `/speckit.specify` on your first feature. The skill auto-creates a Plane project and populates `.claude/skills/plane-dev/references/projects.md`.
+
+### What it does
+
+| Event | Plane Action |
+|-------|-------------|
+| Session start | Detects ticket from branch name, loads ticket state |
+| `feat:` commit | Adds commit comment to ticket, marks child tasks Done |
+| PR gate passes | Links PR to parent ticket, moves to In Review |
+| PR created | Moves parent ticket to Done |
+| `/speckit.specify` | Creates Plane project + parent ticket |
+| `/speckit.taskstoissues --plane` | Creates child tickets from tasks.md |
+
+Without `PLANE_ENABLED=1`, all Plane integration is silently skipped.


### PR DESCRIPTION
## Summary

- Gates all Plane hook context injection behind `PLANE_ENABLED=1` env var — without it, all Plane integration is silently skipped
- Updates speckit.specify and speckit.taskstoissues commands to check `PLANE_ENABLED` before Plane mode
- Adds Setup section to plane-dev skill documenting the env var requirement
- Adds Plane Integration section to README with full setup instructions (env var, MCP server, project registry)

## Test plan

- [ ] Without `PLANE_ENABLED`: hooks output no Plane context on branches with `PROJ-N` pattern
- [ ] With `PLANE_ENABLED=1`: hooks output Plane context as before
- [ ] README renders Plane setup instructions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)